### PR TITLE
Remove CERNLIB dependence in aao_norad, aao_rad

### DIFF
--- a/aao_norad/Makefile
+++ b/aao_norad/Makefile
@@ -1,10 +1,10 @@
 OBJ=  aao.o aao_norad.o cgln_amps.o daresbury.o dsigma.o dvmpw.o dvmpx.o helicity_amps.o interp.o legendre.o maid_lee.o multipole_amps.o read_sf_file.o splie2.o splin2.o spline.o splint.o xsection.o 
 OBJC=  unixtime.o 
 
-CERNLIBS =  -L/apps/cernlib/x86_64_rhel6_4.7.2/2005/lib  -lmathlib  -lpacklib 
+#CERNLIBS =  -L/apps/cernlib/x86_64_rhel6_4.7.2/2005/lib  -lmathlib  -lpacklib 
  
 aao_rad : $(OBJ) $(OBJC)
-	gfortran  -o   aao_rad  $(addprefix build/, $(OBJ)) build/$(OBJC) $(CERNLIBS) 
+	gfortran  -o   aao_rad  $(addprefix build/, $(OBJ)) build/$(OBJC) 
 $(OBJ) : %.o: %.F
 	gfortran -fno-automatic -ffixed-line-length-none -fno-second-underscore -funroll-loops -fomit-frame-pointer  -c $< -o build/$@  
 $(OBJC) : %.o: %.c

--- a/aao_norad/aao_norad.F
+++ b/aao_norad/aao_norad.F
@@ -77,8 +77,8 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       
       real*4 ntp(22)
 
-      common /pawc/h(1000000)
-      common/quest/iquest(100)
+clcs      common /pawc/h(1000000)
+clcs      common/quest/iquest(100)
       common/ntup/ntp
       
       integer h,nevent,nmax,istat,icycle
@@ -205,16 +205,16 @@ c     seed_source: 0= use unix timestamp from machine time to generate seed, oth
       open(unit=14,file=file_sum)
       open(unit=13,file=file_lund)
 
-      call hlimit(1000000)
-      iquest(10)	= 65000
-      call hropen(1,'AONORAD',filerz,'NQ',8191,istat)
-      call hbset('BSIZE',8176,istat)
-      call hbnt(10,'AONORAD',' ')
-      call hbname(10,' ',0,'$clear')
-      call hbname(10,'AONORAD',ntp(1),'ES:R,EP:R,THETE:R,
-     *W:R,PPX:R,PPY:R,PPZ:R,EPROT:R,PPIX:R,PPIY:R,PPIZ:R,
-     *EPI:R,CSTCM:R,PHICM:R,MM:R,QX:R,QZ:R,Q0:R,CSTHE:R,
-     *HEL:R,ASYM:R,Q2:R')
+clcs      call hlimit(1000000)
+clcs      iquest(10)	= 65000
+clcs      call hropen(1,'AONORAD',filerz,'NQ',8191,istat)
+clcs      call hbset('BSIZE',8176,istat)
+clcs      call hbnt(10,'AONORAD',' ')
+clcs      call hbname(10,' ',0,'$clear')
+clcs      call hbname(10,'AONORAD',ntp(1),'ES:R,EP:R,THETE:R,
+clcs     *W:R,PPX:R,PPY:R,PPZ:R,EPROT:R,PPIX:R,PPIY:R,PPIZ:R,
+clcs     *EPI:R,CSTCM:R,PHICM:R,MM:R,QX:R,QZ:R,Q0:R,CSTHE:R,
+clcs     *HEL:R,ASYM:R,Q2:R')
 
       bosout = file_bos
       recname = 'MCEVENT'
@@ -396,7 +396,7 @@ c     if mcall .gt. 0 generate mcall n-tuple events.
         ntp(21)     = asym_p
         ntp(22)     = q2
 
-        call hfnt(10)
+clcs        call hfnt(10)
         
         nevent = nevent+1
         
@@ -573,8 +573,9 @@ c     electron phase space =2*pi*uq2rng*eprng
       if (nevent .gt. nmax) go to 50
  30   go to 20
 
- 50   call hrout(0,icycle,' ')
-      call hrend('AONORAD')
+ 50   continue
+clcs      call hrout(0,icycle,' ')
+clcs      call hrend('AONORAD')
 c      if (boso.eq.1) call bos_end(recname)
       
       write(14,*)' AO Calculation of Single Pion Production',
@@ -597,7 +598,7 @@ c      if (boso.eq.1) call bos_end(recname)
      *    ,' seconds'
       close(unit=12)
       close(unit=14)
-      close(unit=1)
+clcs      close(unit=1)
 
  99   continue
  

--- a/aao_norad/aao_norad.F
+++ b/aao_norad/aao_norad.F
@@ -3,6 +3,7 @@ c
 c     This program makes an n-tuple that can be used with Paw and GSIM to
 c     make distributions of energies, angles, resonance mass resulting 
 c     from non-radiative pion production on a proton.
+c
 c     The n-tuple contains the true hadronic invariant mass (W), the components 
 c     of the proton momentum (PPX, PPY, PPZ),
 c     the proton energy (EP), the pion momentum (PPIX, PPIY, PPIZ) and
@@ -643,7 +644,7 @@ C
       ENDIF
 C
       J = 1 + (97*IY)/M
-      IF(J.GT.97 .OR. J.LT.1) PAUSE
+      IF(J.GT.97 .OR. J.LT.1) STOP
       IY   = IR(J)
       MYRAN = IY*RM
       IDUM = MOD(IA*IDUM+IC,M)

--- a/aao_norad/fint.F
+++ b/aao_norad/fint.F
@@ -1,0 +1,84 @@
+*
+* $Id: fint.F,v 1.1.1.1 1996/02/15 17:48:36 mclareni Exp $
+*
+* $Log: fint.F,v $
+* Revision 1.1.1.1  1996/02/15 17:48:36  mclareni
+* Kernlib
+*
+*
+#include "kernnum/pilot.h"
+          FUNCTION FINT(NARG,ARG,NENT,ENT,TABLE)
+C
+C   INTERPOLATION ROUTINE. AUTHOR C. LETERTRE.
+C   MODIFIED BY B. SCHORR, 1.07.1982.
+C
+          INTEGER   NENT(9)
+          REAL      ARG(9),   ENT(9),   TABLE(9)
+          INTEGER   INDEX(32)
+          REAL      WEIGHT(32)
+          LOGICAL   MFLAG,    RFLAG
+          FINT  =  0.
+          IF(NARG .LT. 1  .OR.  NARG .GT. 5)  GOTO 300
+          LMAX      =  0
+          ISTEP     =  1
+          KNOTS     =  1
+          INDEX(1)  =  1
+          WEIGHT(1) =  1.
+          DO 100    N  =  1, NARG
+             X     =  ARG(N)
+             NDIM  =  NENT(N)
+             LOCA  =  LMAX
+             LMIN  =  LMAX + 1
+             LMAX  =  LMAX + NDIM
+             IF(NDIM .GT. 2)  GOTO 10
+             IF(NDIM .EQ. 1)  GOTO 100
+             H  =  X - ENT(LMIN)
+             IF(H .EQ. 0.)  GOTO 90
+             ISHIFT  =  ISTEP
+             IF(X-ENT(LMIN+1) .EQ. 0.)  GOTO 21
+             ISHIFT  =  0
+             ETA     =  H / (ENT(LMIN+1) - ENT(LMIN))
+             GOTO 30
+  10         LOCB  =  LMAX + 1
+  11         LOCC  =  (LOCA+LOCB) / 2
+             IF(X-ENT(LOCC))  12, 20, 13
+  12         LOCB  =  LOCC
+             GOTO 14
+  13         LOCA  =  LOCC
+  14         IF(LOCB-LOCA .GT. 1)  GOTO 11
+             LOCA    =  MIN0( MAX0(LOCA,LMIN), LMAX-1 )
+             ISHIFT  =  (LOCA - LMIN) * ISTEP
+             ETA     =  (X - ENT(LOCA)) / (ENT(LOCA+1) - ENT(LOCA))
+             GOTO 30
+  20         ISHIFT  =  (LOCC - LMIN) * ISTEP
+  21         DO 22  K  =  1, KNOTS
+                INDEX(K)  =  INDEX(K) + ISHIFT
+  22            CONTINUE
+             GOTO 90
+  30         DO 31  K  =  1, KNOTS
+                INDEX(K)         =  INDEX(K) + ISHIFT
+                INDEX(K+KNOTS)   =  INDEX(K) + ISTEP
+                WEIGHT(K+KNOTS)  =  WEIGHT(K) * ETA
+                WEIGHT(K)        =  WEIGHT(K) - WEIGHT(K+KNOTS)
+  31            CONTINUE
+             KNOTS  =  2*KNOTS
+  90         ISTEP  =  ISTEP * NDIM
+ 100         CONTINUE
+          DO 200    K  =  1, KNOTS
+             I  =  INDEX(K)
+             FINT  =  FINT + WEIGHT(K) * TABLE(I)
+ 200         CONTINUE
+          RETURN
+ 300      CALL KERMTR('E104.1',LGFILE,MFLAG,RFLAG)
+          IF(MFLAG) THEN
+             IF(LGFILE .EQ. 0) THEN
+                WRITE(*,1000) NARG
+             ELSE
+                WRITE(LGFILE,1000) NARG
+             ENDIF
+          ENDIF
+          IF(.NOT. RFLAG) CALL ABEND
+          RETURN
+1000      FORMAT( 7X, 24HFUNCTION FINT ... NARG =,I6,
+     +              17H NOT WITHIN RANGE)
+          END

--- a/aao_norad/fint.F
+++ b/aao_norad/fint.F
@@ -6,7 +6,7 @@
 * Kernlib
 *
 *
-#include "kernnum/pilot.h"
+Clcs#include "kernnum/pilot.h"
           FUNCTION FINT(NARG,ARG,NENT,ENT,TABLE)
 C
 C   INTERPOLATION ROUTINE. AUTHOR C. LETERTRE.
@@ -41,7 +41,10 @@ C
              GOTO 30
   10         LOCB  =  LMAX + 1
   11         LOCC  =  (LOCA+LOCB) / 2
-             IF(X-ENT(LOCC))  12, 20, 13
+             IF(X-ENT(LOCC) .LT. 0) GOTO 12
+             IF(X-ENT(LOCC) .EQ. 0) GOTO 20
+             IF(X-ENT(LOCC) .GT. 0) GOTO 13
+Clcs             IF(X-ENT(LOCC))  12, 20, 13
   12         LOCB  =  LOCC
              GOTO 14
   13         LOCA  =  LOCC
@@ -69,15 +72,16 @@ C
              FINT  =  FINT + WEIGHT(K) * TABLE(I)
  200         CONTINUE
           RETURN
- 300      CALL KERMTR('E104.1',LGFILE,MFLAG,RFLAG)
-          IF(MFLAG) THEN
-             IF(LGFILE .EQ. 0) THEN
+ 300      CONTINUE
+Clcs         CALL KERMTR('E104.1',LGFILE,MFLAG,RFLAG)
+Clcs          IF(MFLAG) THEN
+Clcs             IF(LGFILE .EQ. 0) THEN
                 WRITE(*,1000) NARG
-             ELSE
-                WRITE(LGFILE,1000) NARG
-             ENDIF
-          ENDIF
-          IF(.NOT. RFLAG) CALL ABEND
+Clcs             ELSE
+Clcs                WRITE(LGFILE,1000) NARG
+Clcs             ENDIF
+Clcs          ENDIF
+Clcs          IF(.NOT. RFLAG) CALL ABEND
           RETURN
 1000      FORMAT( 7X, 24HFUNCTION FINT ... NARG =,I6,
      +              17H NOT WITHIN RANGE)

--- a/aao_norad/sconstruct
+++ b/aao_norad/sconstruct
@@ -4,8 +4,8 @@ path = ['/usr/bin']
 env = Environment(ENV = {'PATH':path})
 env.Append(FORTRANFLAGS = ['-fno-automatic', '-ffixed-line-length-none', '-fno-second-underscore', '-funroll-loops', '-fomit-frame-pointer'])
 
-env.Append(LIBPATH = ['/apps/cernlib/x86_64_rhel7/2005/lib'])
-env.Append(LIBS = ['kernlib', 'mathlib', 'packlib', 'jetset74', 'lepto651'])
+#env.Append(LIBPATH = ['/apps/cernlib/x86_64_rhel7/2005/lib'])
+#env.Append(LIBS = ['kernlib', 'mathlib', 'packlib', 'jetset74', 'lepto651'])
 #staticlibs = ['kernlib.a', 'mathlib.a', 'packlib.a', 'jetset74.a', 'lepto651.a']
 #env.Append(LIBS = [File(env['CERN']+'/2005/lib/lib'+lib) for lib in staticlibs])
 

--- a/aao_norad/timex.F
+++ b/aao_norad/timex.F
@@ -1,0 +1,22 @@
+*
+* $Id: timex.F,v 1.1.1.1 1996/02/15 17:50:38 mclareni Exp $
+*
+* $Log: timex.F,v $
+* Revision 1.1.1.1  1996/02/15 17:50:38  mclareni
+* Kernlib
+*
+*
+Clcs #include "kerngen/pilot.h"
+Clcs #if defined(CERNLIB_QMVAX)
+Clcs #include "vaxsys/timex.F"
+Clcs #else
+      SUBROUTINE TIMEX (T)
+C
+C CERN PROGLIB# Z007    TIMEX   DUMMY   .VERSION KERNFOR  4.05  821202
+C
+C-    DUMMY FOR NON-ESSENTIAL ROUTINE STILL MISSING ON YOUR MACHINE
+
+      T = 9.
+      RETURN
+      END
+Clcs #endif

--- a/aao_rad/Makefile
+++ b/aao_rad/Makefile
@@ -1,10 +1,10 @@
 OBJ=  aao.o aao_rad.o cgln_amps.o daresbury.o dsigma.o dvmpw.o dvmpx.o helicity_amps.o interp.o legendre.o maid_lee.o multipole_amps.o read_sf_file.o sigmao.o splie2.o splin2.o spline.o splint.o strlen.o xsection.o
 OBJC=  unixtime.o 
 
-CERNLIBS =  -L/apps/cernlib/x86_64_rhel6_4.7.2/2005/lib  -lmathlib  -lpacklib 
+#CERNLIBS =  -L/apps/cernlib/x86_64_rhel6_4.7.2/2005/lib  -lmathlib  -lpacklib 
  
 aao_rad : $(OBJ) $(OBJC)
-	gfortran  -o   aao_rad  $(addprefix build/, $(OBJ)) build/$(OBJC) $(CERNLIBS) 
+	gfortran  -o   aao_rad  $(addprefix build/, $(OBJ)) build/$(OBJC) 
 $(OBJ) : %.o: %.F
 	gfortran -fno-automatic -ffixed-line-length-none -fno-second-underscore -funroll-loops -fomit-frame-pointer  -c $< -o build/$@  
 $(OBJC) : %.o: %.c

--- a/aao_rad/aao_rad.F
+++ b/aao_rad/aao_rad.F
@@ -159,7 +159,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c     Parameters for the n-tuple, which is named func1 and contains
 c     15 elements per event.
 
-      common /pawc/h(5000000)
+clcs      common /pawc/h(5000000)
       integer h,n,nevent,nmax,lrecl,istat,icycle
       parameter (n=32)
       real*4 ntp(n)
@@ -460,9 +460,9 @@ c     set up the ntuple file
 
       lrecl	= 1024
       
-      call hlimit(5000000)
-      call hropen(1,'aaoradgen',filerz,'n',lrecl,istat)
-      call hbookn(10,'func1',n,'aaoradgen',1000,tag)
+Clcs      call hlimit(5000000)
+Clcs      call hropen(1,'aaoradgen',filerz,'n',lrecl,istat)
+Clcs      call hbookn(10,'func1',n,'aaoradgen',1000,tag)
 
       open(unit=12,file=file_out)
 
@@ -1107,7 +1107,7 @@ c     Calculate the members of the n-tuple and ouput it to the rz file.
          ntp(31)= ehel
          ntp(32)= asym_p
 
-         call hfn(10,ntp)
+Clcs         call hfn(10,ntp)
 c         nevent	= nevent+1
         
          do jj = 1,npart
@@ -1279,8 +1279,9 @@ c     Do we have enough events in the n-tuple?
 
 c     Close out the n-tuple file
 
- 50   call hrout(0,icycle,' ')
-      call hrend('aaoradgen')
+ 50   continue
+Clcs      call hrout(0,icycle,' ')
+Clcs      call hrend('aaoradgen')
 
 
       close(12)

--- a/aao_rad/fint.F
+++ b/aao_rad/fint.F
@@ -1,0 +1,88 @@
+*
+* $Id: fint.F,v 1.1.1.1 1996/02/15 17:48:36 mclareni Exp $
+*
+* $Log: fint.F,v $
+* Revision 1.1.1.1  1996/02/15 17:48:36  mclareni
+* Kernlib
+*
+*
+Clcs#include "kernnum/pilot.h"
+          FUNCTION FINT(NARG,ARG,NENT,ENT,TABLE)
+C
+C   INTERPOLATION ROUTINE. AUTHOR C. LETERTRE.
+C   MODIFIED BY B. SCHORR, 1.07.1982.
+C
+          INTEGER   NENT(9)
+          REAL      ARG(9),   ENT(9),   TABLE(9)
+          INTEGER   INDEX(32)
+          REAL      WEIGHT(32)
+          LOGICAL   MFLAG,    RFLAG
+          FINT  =  0.
+          IF(NARG .LT. 1  .OR.  NARG .GT. 5)  GOTO 300
+          LMAX      =  0
+          ISTEP     =  1
+          KNOTS     =  1
+          INDEX(1)  =  1
+          WEIGHT(1) =  1.
+          DO 100    N  =  1, NARG
+             X     =  ARG(N)
+             NDIM  =  NENT(N)
+             LOCA  =  LMAX
+             LMIN  =  LMAX + 1
+             LMAX  =  LMAX + NDIM
+             IF(NDIM .GT. 2)  GOTO 10
+             IF(NDIM .EQ. 1)  GOTO 100
+             H  =  X - ENT(LMIN)
+             IF(H .EQ. 0.)  GOTO 90
+             ISHIFT  =  ISTEP
+             IF(X-ENT(LMIN+1) .EQ. 0.)  GOTO 21
+             ISHIFT  =  0
+             ETA     =  H / (ENT(LMIN+1) - ENT(LMIN))
+             GOTO 30
+  10         LOCB  =  LMAX + 1
+  11         LOCC  =  (LOCA+LOCB) / 2
+             IF(X-ENT(LOCC) .LT. 0) GOTO 12
+             IF(X-ENT(LOCC) .EQ. 0) GOTO 20
+             IF(X-ENT(LOCC) .GT. 0) GOTO 13
+Clcs             IF(X-ENT(LOCC))  12, 20, 13
+  12         LOCB  =  LOCC
+             GOTO 14
+  13         LOCA  =  LOCC
+  14         IF(LOCB-LOCA .GT. 1)  GOTO 11
+             LOCA    =  MIN0( MAX0(LOCA,LMIN), LMAX-1 )
+             ISHIFT  =  (LOCA - LMIN) * ISTEP
+             ETA     =  (X - ENT(LOCA)) / (ENT(LOCA+1) - ENT(LOCA))
+             GOTO 30
+  20         ISHIFT  =  (LOCC - LMIN) * ISTEP
+  21         DO 22  K  =  1, KNOTS
+                INDEX(K)  =  INDEX(K) + ISHIFT
+  22            CONTINUE
+             GOTO 90
+  30         DO 31  K  =  1, KNOTS
+                INDEX(K)         =  INDEX(K) + ISHIFT
+                INDEX(K+KNOTS)   =  INDEX(K) + ISTEP
+                WEIGHT(K+KNOTS)  =  WEIGHT(K) * ETA
+                WEIGHT(K)        =  WEIGHT(K) - WEIGHT(K+KNOTS)
+  31            CONTINUE
+             KNOTS  =  2*KNOTS
+  90         ISTEP  =  ISTEP * NDIM
+ 100         CONTINUE
+          DO 200    K  =  1, KNOTS
+             I  =  INDEX(K)
+             FINT  =  FINT + WEIGHT(K) * TABLE(I)
+ 200         CONTINUE
+          RETURN
+ 300      CONTINUE
+Clcs         CALL KERMTR('E104.1',LGFILE,MFLAG,RFLAG)
+Clcs          IF(MFLAG) THEN
+Clcs             IF(LGFILE .EQ. 0) THEN
+                WRITE(*,1000) NARG
+Clcs             ELSE
+Clcs                WRITE(LGFILE,1000) NARG
+Clcs             ENDIF
+Clcs          ENDIF
+Clcs          IF(.NOT. RFLAG) CALL ABEND
+          RETURN
+1000      FORMAT( 7X, 24HFUNCTION FINT ... NARG =,I6,
+     +              17H NOT WITHIN RANGE)
+          END

--- a/aao_rad/sconstruct
+++ b/aao_rad/sconstruct
@@ -1,11 +1,13 @@
 import os
 
 path = ['/usr/bin']
-env = Environment(ENV = {'PATH':path}, CERN = os.environ['CERN'])
+env = Environment(ENV = {'PATH':path})
 env.Append(FORTRANFLAGS = ['-fno-automatic', '-ffixed-line-length-none', '-fno-second-underscore', '-funroll-loops', '-fomit-frame-pointer'])
 
-staticlibs = ['kernlib.a', 'mathlib.a', 'packlib.a', 'jetset74.a', 'lepto651.a']
-env.Append(LIBS = [File(env['CERN']+'/2005/lib/lib'+lib) for lib in staticlibs])
+#env.Append(LIBPATH = ['/apps/cernlib/x86_64_rhel7/2005/lib'])
+#env.Append(LIBS = ['kernlib', 'mathlib', 'packlib', 'jetset74', 'lepto651'])
+#staticlibs = ['kernlib.a', 'mathlib.a', 'packlib.a', 'jetset74.a', 'lepto651.a']
+#env.Append(LIBS = [File(env['CERN']+'/2005/lib/lib'+lib) for lib in staticlibs])
 
 Export('env')
 

--- a/aao_rad/timex.F
+++ b/aao_rad/timex.F
@@ -1,0 +1,22 @@
+*
+* $Id: timex.F,v 1.1.1.1 1996/02/15 17:50:38 mclareni Exp $
+*
+* $Log: timex.F,v $
+* Revision 1.1.1.1  1996/02/15 17:50:38  mclareni
+* Kernlib
+*
+*
+Clcs #include "kerngen/pilot.h"
+Clcs #if defined(CERNLIB_QMVAX)
+Clcs #include "vaxsys/timex.F"
+Clcs #else
+      SUBROUTINE TIMEX (T)
+C
+C CERN PROGLIB# Z007    TIMEX   DUMMY   .VERSION KERNFOR  4.05  821202
+C
+C-    DUMMY FOR NON-ESSENTIAL ROUTINE STILL MISSING ON YOUR MACHINE
+
+      T = 9.
+      RETURN
+      END
+Clcs #endif


### PR DESCRIPTION
Create local versions of FINT.F and TIMEX.F without references to CERNLIB 
Comment out HBOOK calls to create, fill and close ntuple files.
Comment out CERNLIB references in sconstruct and Makefile.